### PR TITLE
Fix: localhost is not alway set to 127.0.0.1

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,6 @@
 location PATHTOCHANGE/ {
        rewrite                ^PATHTOCHANGE$ PATHTOCHANGE/ permanent;
-       proxy_pass             http://localhost:9001/;
+       proxy_pass             http://127.0.0.1:9001/;
        proxy_set_header       Host $host;
        proxy_buffering off;
 }


### PR DESCRIPTION
In result, locahost can be set to ::1, therefor a backend service that listen on 0.0.0.0 and doesn't support ipv6 won't be reachable.
